### PR TITLE
Fix typo in server.go

### DIFF
--- a/server.go
+++ b/server.go
@@ -19,7 +19,7 @@ func main() {
 		port = defaultPort
 	}
 
-	srv := handler.NewDefaultServer(generated.NewExescutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
+	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	http.Handle("/query", srv)


### PR DESCRIPTION
server.go wasn't compiling due to a typo in "NewExecutableSchema". I corrected it.